### PR TITLE
Fix unicode flag and add some functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ option(URIPARSER_DISABLE_TESTS "Disable building and running tests" OFF)
 option(URIPARSER_BUILD_DOCS "Whether or not to build documentation" OFF)
 option(URIPARSER_DISABLE_ANSI "Disable ANSI support" OFF)
 option(URIPARSER_DISABLE_UNICODE "Disable Unicode support" OFF)
+if (MSVC)
+  if (BUILD_SHARED_LIBS)
+    set(DEFAULT_MSVC_STATIC_RUNTIME OFF)
+  else ()
+    set(DEFAULT_MSVC_STATIC_RUNTIME ON)
+  endif ()
+
+  option(URIPARSER_MSVC_STATIC_RUNTIME "Link to static CRT (/MT rather than /MD)" ${DEFAULT_MSVC_STATIC_RUNTIME})
+endif ()
 
 check_c_source_compiles(
 	"
@@ -65,6 +74,22 @@ endif ()
 if (URIPARSER_DISABLE_UNICODE)
 	target_compile_definitions(liburiparser PUBLIC -DURI_NO_UNICODE)
 endif ()
+
+if (MSVC AND URIPARSER_MSVC_STATIC_RUNTIME)
+  # In case we are building static libraries, link also the runtime library statically
+  # so that MSVCR*.DLL is not required at runtime.
+  # https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
+  # This is achieved by replacing msvc option /MD with /MT and /MDd with /MTd
+  # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+    foreach (flag_var
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+      if (${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif ()
+    endforeach ()
+endif ()
+
 
 target_include_directories(liburiparser	PUBLIC include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ include(CPack)
 
 option(URIPARSER_DISABLE_TESTS "Disable building and running tests" OFF)
 option(URIPARSER_BUILD_DOCS "Whether or not to build documentation" OFF)
-option(URIPARSER_DISABLE_UNICODE "Disable Unicode support, using ANSI characters instead" OFF)
+option(URIPARSER_DISABLE_ANSI "Disable ANSI support" OFF)
+option(URIPARSER_DISABLE_UNICODE "Disable Unicode support" OFF)
 
 check_c_source_compiles(
 	"
@@ -58,9 +59,10 @@ add_library(liburiparser
 
 set_target_properties(liburiparser PROPERTIES OUTPUT_NAME "uriparser")
 
-if (URIPARSER_DISABLE_UNICODE)
+if (URIPARSER_DISABLE_ANSI)
 	target_compile_definitions(liburiparser PUBLIC -DURI_NO_ANSI)
-else ()
+endif ()
+if (URIPARSER_DISABLE_UNICODE)
 	target_compile_definitions(liburiparser PUBLIC -DURI_NO_UNICODE)
 endif ()
 


### PR DESCRIPTION
I noticed that the disable unicode flag disabled ansi so I figured I'd fix it and while I was in there I added a couple of features:

- Now you can disable either unicode or ansi or leave both in. In theory you could disable both, but the build will probably complain.
- With MSVC, Added the ability to link in the static runtime rather than the dynamic one. It will do this by default if you are building a static library, although there is an option to override this.